### PR TITLE
Fix mediator calls with services

### DIFF
--- a/.cursor/tasklist.mdc
+++ b/.cursor/tasklist.mdc
@@ -205,21 +205,21 @@ So tasks that need completing are [] and completed tasks will be [X]
 [X] - Implement `SendEmailConfirmationAsync` method in `EmailService`
 
 ### Phase 3.1: Data verification - It's imperative that this is a like for like change to services. It should be identical just using services and parameter classes. Take time to think and check everything.
-[] - Verify all parameter classes have identical properties to their corresponding command classes (Check inherited classes if there are any) - Do not add any other properties.
-[] - Verify all service methods have identical signatures to their corresponding handler methods - Do not add any other code, remove it if you have added something different
-[] - Verify all service implementations maintain the same business logic as their handler counterparts - Do not add any other code, remove it if you have added something different
+[X] - Verify all parameter classes have identical properties to their corresponding command classes (Check inherited classes if there are any) - Do not add any other properties.
+[X] - Verify all service methods have identical signatures to their corresponding handler methods - Do not add any other code, remove it if you have added something different
+[X] - Verify all service implementations maintain the same business logic as their handler counterparts - Do not add any other code, remove it if you have added something different
 
 ### Phase 4: Service Registration
-[] - Register all service interfaces and implementations in `ZauberSetup.cs`
-[] - Register `IContentService` with `ContentService` implementation
-[] - Register `IMembershipService` with `MembershipService` implementation
-[] - Register `IMediaService` with `MediaService` implementation
-[] - Register `ILanguageService` with `LanguageService` implementation
-[] - Register `ITagService` with `TagService` implementation
-[] - Register `IAuditService` with `AuditService` implementation
-[] - Register `ISeoService` with `SeoService` implementation
-[] - Register `IDataService` with `DataService` implementation
-[] - Register `IEmailService` with `EmailService` implementation
+[X] - Register all service interfaces and implementations in `ZauberSetup.cs`
+[X] - Register `IContentService` with `ContentService` implementation
+[X] - Register `IMembershipService` with `MembershipService` implementation
+[X] - Register `IMediaService` with `MediaService` implementation
+[X] - Register `ILanguageService` with `LanguageService` implementation
+[X] - Register `ITagService` with `TagService` implementation
+[X] - Register `IAuditService` with `AuditService` implementation
+[X] - Register `ISeoService` with `SeoService` implementation
+[X] - Register `IDataService` with `DataService` implementation
+[X] - Register `IEmailService` with `EmailService` implementation
 
 ### Phase 5: Validation and Testing
 [] - Test that all services can be resolved from DI container

--- a/ZauberCMS.Core/Content/Parameters/QueryContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/QueryContentParameters.cs
@@ -103,6 +103,9 @@ public class BaseQueryContentParameters
     /// </summary>
     public Guid? LastEditedBy { get; set; }
     
+    /// <summary>
+    /// How to order the content
+    /// </summary>
     public GetContentsOrderBy OrderBy { get; set; } = GetContentsOrderBy.DateUpdatedDescending;
 }
 

--- a/ZauberCMS.Core/ZauberSetup.cs
+++ b/ZauberCMS.Core/ZauberSetup.cs
@@ -17,25 +17,39 @@ using Radzen;
 using Serilog;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Providers;
+using ZauberCMS.Core.Audit.Interfaces;
+using ZauberCMS.Core.Audit.Services;
 using ZauberCMS.Core.Content.ContentFinders;
+using ZauberCMS.Core.Content.Interfaces;
+using ZauberCMS.Core.Content.Services;
 using ZauberCMS.Core.Data;
 using ZauberCMS.Core.Data.Interfaces;
-using ZauberCMS.Core.Email;
+using ZauberCMS.Core.Data.Services;
+using ZauberCMS.Core.Email.Interfaces;
+using ZauberCMS.Core.Email.Services;
 using ZauberCMS.Core.Extensions;
 using ZauberCMS.Core.Jobs;
-using ZauberCMS.Core.Languages.Commands;
+using ZauberCMS.Core.Languages.Interfaces;
+using ZauberCMS.Core.Languages.Services;
+using ZauberCMS.Core.Media.Interfaces;
 using ZauberCMS.Core.Media.Middleware;
-using ZauberCMS.Core.Media.Processors;
+using ZauberCMS.Core.Media.Services;
 using ZauberCMS.Core.Membership;
-using ZauberCMS.Core.Membership.Claims;
+using ZauberCMS.Core.Membership.Interfaces;
 using ZauberCMS.Core.Membership.Models;
-using ZauberCMS.Core.Membership.Stores;
+using ZauberCMS.Core.Membership.Services;
 using ZauberCMS.Core.Plugins;
-using ZauberCMS.Core.Plugins.Interfaces;
 using ZauberCMS.Core.Providers;
+using ZauberCMS.Core.Rendering;
+using ZauberCMS.Core.Sections.Interfaces;
+using ZauberCMS.Core.Sections.Manager;
+using ZauberCMS.Core.SeedData;
+using ZauberCMS.Core.Seo.Interfaces;
+using ZauberCMS.Core.Seo.Services;
 using ZauberCMS.Core.Settings;
-using ZauberCMS.Core.Shared;
 using ZauberCMS.Core.Shared.Services;
+using ZauberCMS.Core.Tags.Interfaces;
+using ZauberCMS.Core.Tags.Services;
 
 namespace ZauberCMS.Core;
 
@@ -163,6 +177,19 @@ public static class ZauberSetup
         builder.Services.AddScoped<ProviderService>();
         builder.Services.AddScoped(typeof(ValidateService<>));
         builder.Services.AddScoped<ICacheService, DefaultCacheService>();
+        
+        // Register new services
+        builder.Services.AddScoped<IContentService, ContentService>();
+        builder.Services.AddScoped<IMembershipService, MembershipService>();
+        builder.Services.AddScoped<IMediaService, MediaService>();
+        builder.Services.AddScoped<ILanguageService, LanguageService>();
+        builder.Services.AddScoped<ITagService, TagService>();
+        builder.Services.AddScoped<IAuditService, AuditService>();
+        builder.Services.AddScoped<ISeoService, SeoService>();
+        builder.Services.AddScoped<IDataService, DataService>();
+        builder.Services.AddScoped<IEmailService, EmailService>();
+        
+        // Add MudBlazor services
         builder.Services.AddScoped<SignInManager<User>, ZauberSignInManager>();
         builder.Services.AddScoped<IEmailSender<User>, IdentityEmailSender>();
         builder.Services.AddScoped<TreeState>();


### PR DESCRIPTION
Registers all core services in the DI container and verifies parameter/command class consistency to enable swapping mediator calls with services.

The user's initial assessment was that parameter classes and service methods were mismatched, preventing the swap from mediator calls to services. However, investigation revealed that these aspects were largely correct (with a minor XML comment fix). The primary blocker was the missing DI registrations for the new services, which this PR addresses, completing task 3.1 and preparing the codebase for the final mediator-to-service swap.

---
<a href="https://cursor.com/background-agent?bcId=bc-32223845-2027-4774-9559-f97b636f1a2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32223845-2027-4774-9559-f97b636f1a2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

