### PR TITLE
Replace mediator by implementing new services

### DIFF
--- a/ZauberCMS.Core/Audit/Interfaces/IAuditService.cs
+++ b/ZauberCMS.Core/Audit/Interfaces/IAuditService.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Audit.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Audit.Interfaces;
+
+public interface IAuditService
+{
+    Task<HandlerResult<Models.Audit>> SaveAuditAsync(SaveAuditParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Models.Audit>> QueryAuditsAsync(QueryAuditsParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<int>> CleanupOldAuditsAsync(CleanupOldAuditsParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Audit/Parameters/CleanupOldAuditsParameters.cs
+++ b/ZauberCMS.Core/Audit/Parameters/CleanupOldAuditsParameters.cs
@@ -1,0 +1,6 @@
+namespace ZauberCMS.Core.Audit.Parameters;
+
+public class CleanupOldAuditsParameters
+{
+    public int DaysToKeep { get; set; } = 90;
+}

--- a/ZauberCMS.Core/Audit/Parameters/QueryAuditsParameters.cs
+++ b/ZauberCMS.Core/Audit/Parameters/QueryAuditsParameters.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Audit.Parameters;
+
+public class QueryAuditsParameters
+{
+    public bool AsNoTracking { get; set; } = true;
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public string? Username { get; set; }
+    public GetAuditsOrderBy OrderBy { get; set; } = GetAuditsOrderBy.DateCreatedDescending;
+    public Expression<Func<Models.Audit, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Models.Audit>>? Query { get; set; }
+}
+
+public enum GetAuditsOrderBy
+{
+    DateCreated,
+    DateCreatedDescending,
+    Username
+}

--- a/ZauberCMS.Core/Audit/Parameters/SaveAuditParameters.cs
+++ b/ZauberCMS.Core/Audit/Parameters/SaveAuditParameters.cs
@@ -1,0 +1,8 @@
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Audit.Parameters;
+
+public class SaveAuditParameters
+{
+    public Models.Audit? Audit { get; set; }
+}

--- a/ZauberCMS.Core/Content/Interfaces/IContentService.cs
+++ b/ZauberCMS.Core/Content/Interfaces/IContentService.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Content.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Interfaces;
+
+public interface IContentService
+{
+    Task<Models.Content?> GetContentAsync(GetContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Models.Content>> SaveContentAsync(SaveContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Models.Content>> QueryContentAsync(QueryContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Models.Content>> DeleteContentAsync(DeleteContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Models.Content>> CopyContentAsync(CopyContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<EntryModel> GetContentFromRequestAsync(GetContentFromRequestParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<ContentType?> GetContentTypeAsync(GetContentTypeParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<ContentType>> SaveContentTypeAsync(SaveContentTypeParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<ContentType>> QueryContentTypesAsync(QueryContentTypesParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<ContentType>> DeleteContentTypeAsync(DeleteContentTypeParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<Domain> GetDomainAsync(GetDomainParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Domain>> SaveDomainAsync(SaveDomainParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Domain>> QueryDomainAsync(QueryDomainParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Domain?>> DeleteDomainAsync(DeleteDomainParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<bool> AnyContentAsync(AnyContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<bool> HasChildContentAsync(HasChildContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<bool> HasChildContentTypeAsync(HasChildContentTypeParameters parameters, CancellationToken cancellationToken = default);
+    Task<Dictionary<object, string>> GetContentLanguagesAsync(GetContentLanguagesParameters parameters, CancellationToken cancellationToken = default);
+    Task<List<Domain>> GetCachedDomainsAsync(CachedDomainsParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<UnpublishedContent>> ClearUnpublishedContentAsync(ClearUnpublishedContentParameters parameters, CancellationToken cancellationToken = default);
+    Task<DataGridResult<Models.Content>> GetDataGridContentAsync(DataGridContentParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Content/Parameters/AnyContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/AnyContentParameters.cs
@@ -1,0 +1,5 @@
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class AnyContentParameters
+{
+}

--- a/ZauberCMS.Core/Content/Parameters/CachedDomainsParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/CachedDomainsParameters.cs
@@ -1,0 +1,5 @@
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class CachedDomainsParameters
+{
+}

--- a/ZauberCMS.Core/Content/Parameters/ClearUnpublishedContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/ClearUnpublishedContentParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class ClearUnpublishedContentParameters
+{
+    public Guid ContentId { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/CopyContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/CopyContentParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class CopyContentParameters
+{
+    public Guid ContentToCopy { get; set; }
+    public bool IncludeDescendants { get; set; }
+    public Guid? CopyTo { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/DataGridContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/DataGridContentParameters.cs
@@ -1,0 +1,11 @@
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class DataGridContentParameters : BaseQueryContentParameters
+{
+    public int Skip { get; set; }
+    public int Take { get; set; } = 20;
+    public string? Order { get; set; }
+    public string? Filter { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/DeleteContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/DeleteContentParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class DeleteContentParameters
+{
+    public Guid ContentId { get; set; }
+    public bool MoveToRecycleBin { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/DeleteContentTypeParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/DeleteContentTypeParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class DeleteContentTypeParameters
+{
+    public Guid ContentTypeId { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/DeleteDomainParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/DeleteDomainParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class DeleteDomainParameters
+{
+    public Guid? Id { get; set; }
+    public Guid? ContentId { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/GetContentFromRequestParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/GetContentFromRequestParameters.cs
@@ -1,0 +1,10 @@
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class GetContentFromRequestParameters
+{
+    public string? Slug { get; set; }
+    public bool IsRootContent { get; set; }
+    public bool IncludeChildren { get; set; }
+    public bool IgnoreInternalRedirect { get; set; }
+    public string? Url { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/GetContentLanguagesParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/GetContentLanguagesParameters.cs
@@ -1,0 +1,5 @@
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class GetContentLanguagesParameters
+{
+}

--- a/ZauberCMS.Core/Content/Parameters/GetContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/GetContentParameters.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class GetContentParameters
+{
+    public bool Cached { get; set; }
+    public bool IncludeUnpublishedContent { get; set; }
+    public bool IncludeContentRoles { get; set; }
+    public Guid? Id { get; set; }
+    public bool IncludeChildren { get; set; }
+    public bool IncludeParent { get; set; }
+    public bool IncludeUnpublished { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public string ContentTypeAlias { get; set; } = string.Empty;
+}

--- a/ZauberCMS.Core/Content/Parameters/GetContentTypeParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/GetContentTypeParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class GetContentTypeParameters
+{
+    public Guid Id { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/GetDomainParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/GetDomainParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Content.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class GetDomainParameters
+{
+    public Guid? Id { get; set; }
+    public bool AsNoTracking { get; set; }
+    public string? Url { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/HasChildContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/HasChildContentParameters.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class HasChildContentParameters
+{
+    public bool Cached { get; set; } = true;
+    public Guid ParentId { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/HasChildContentTypeParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/HasChildContentTypeParameters.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class HasChildContentTypeParameters
+{
+    public bool Cached { get; set; } = true;
+    public Guid ParentId { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/QueryContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/QueryContentParameters.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class QueryContentParameters : BaseQueryContentParameters
+{
+    public bool Cached { get; set; }
+    public List<Guid> Ids { get; set; } = [];
+    public List<string> TagSlugs { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public string? SearchTerm { get; set; }
+    public bool IncludeUnpublished { get; set; }
+    public bool IncludeContentRoles { get; set; }
+    public bool OnlyUnpublished { get; set; }
+    public bool? IsDeleted { get; set; } = false;
+    public bool RootContentOnly { get; set; }
+    public Expression<Func<Content.Models.Content, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Content.Models.Content>>? Query { get; set; }
+}
+
+public class BaseQueryContentParameters
+{
+    public string ContentTypeAlias { get; set; } = string.Empty;
+    public Guid? ContentTypeId { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public bool IncludeChildren { get; set; }
+    public Guid? ParentId { get; set; }
+    public Guid? LastEditedBy { get; set; }
+    public GetContentsOrderBy OrderBy { get; set; } = GetContentsOrderBy.DateUpdatedDescending;
+}
+
+public enum GetContentsOrderBy
+{
+    DateUpdated,
+    DateUpdatedDescending,
+    DateCreated,
+    DateCreatedDescending,
+    SortOrder
+}

--- a/ZauberCMS.Core/Content/Parameters/QueryContentTypesParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/QueryContentTypesParameters.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class QueryContentTypesParameters
+{
+    public bool IncludeElementTypes { get; set; }
+    public bool OnlyElementTypes { get; set; }
+    public bool OnlyCompositions { get; set; }
+    public bool IncludeCompositions { get; set; }
+    public bool RootOnly { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public bool IncludeFolders { get; set; }
+    public bool OnlyFolders { get; set; }
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public Guid? ParentId { get; set; }
+    public string? SearchTerm { get; set; }
+    public GetContentTypesOrderBy OrderBy { get; set; } = GetContentTypesOrderBy.DateUpdatedDescending;
+    public Expression<Func<ContentType, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<ContentType>>? Query { get; set; }
+}
+
+public enum GetContentTypesOrderBy
+{
+    DateUpdated,
+    DateUpdatedDescending,
+    DateCreated,
+    DateCreatedDescending,
+    Name
+}

--- a/ZauberCMS.Core/Content/Parameters/QueryDomainParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/QueryDomainParameters.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class QueryDomainParameters
+{
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public bool IncludeChildren { get; set; }
+    public Guid? ContentId { get; set; }
+    public Guid? LanguageId { get; set; }
+    public GetDomainOrderBy OrderBy { get; set; } = GetDomainOrderBy.DateCreatedDescending;
+    public Expression<Func<Domain, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Domain>>? Query { get; set; }
+}
+
+public enum GetDomainOrderBy
+{
+    DateCreated,
+    DateCreatedDescending,
+    Url
+}

--- a/ZauberCMS.Core/Content/Parameters/SaveContentParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/SaveContentParameters.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class SaveContentParameters
+{
+    public Content.Models.Content? Content { get; set; }
+    public List<Role> Roles { get; set; } = [];
+    public bool UpdateContentRoles { get; set; }
+    public bool ExcludePropertyData { get; set; }
+    public bool SaveUnpublishedOnly { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/SaveContentTypeParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/SaveContentTypeParameters.cs
@@ -1,0 +1,9 @@
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class SaveContentTypeParameters
+{
+    public ContentType? ContentType { get; set; }
+}

--- a/ZauberCMS.Core/Content/Parameters/SaveDomainParameters.cs
+++ b/ZauberCMS.Core/Content/Parameters/SaveDomainParameters.cs
@@ -1,0 +1,9 @@
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Content.Parameters;
+
+public class SaveDomainParameters
+{
+    public Domain? Domain { get; set; }
+}

--- a/ZauberCMS.Core/Content/Services/ContentService.cs
+++ b/ZauberCMS.Core/Content/Services/ContentService.cs
@@ -1,0 +1,1155 @@
+using System.Security.Cryptography;
+using System.Text;
+using AutoMapper;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Content.Interfaces;
+using ZauberCMS.Core.Content.Models;
+using ZauberCMS.Core.Content.Parameters;
+using ZauberCMS.Core.Data;
+using ZauberCMS.Core.Extensions;
+using ZauberCMS.Core.Languages.Interfaces;
+using ZauberCMS.Core.Plugins;
+using ZauberCMS.Core.Settings;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Shared.Services;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Content.Services;
+
+public class ContentService : IContentService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IZauberDbContext _dbContext;
+    private readonly ICacheService _cacheService;
+    private readonly IMapper _mapper;
+    private readonly IOptions<ZauberSettings> _settings;
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private readonly UserManager<User> _userManager;
+    private readonly ExtensionManager _extensionManager;
+    private readonly AppState _appState;
+    private readonly ILanguageService _languageService;
+
+    public ContentService(
+        IServiceProvider serviceProvider,
+        IZauberDbContext dbContext,
+        ICacheService cacheService,
+        IMapper mapper,
+        IOptions<ZauberSettings> settings,
+        AuthenticationStateProvider authenticationStateProvider,
+        UserManager<User> userManager,
+        ExtensionManager extensionManager,
+        AppState appState,
+        ILanguageService languageService)
+    {
+        _serviceProvider = serviceProvider;
+        _dbContext = dbContext;
+        _cacheService = cacheService;
+        _mapper = mapper;
+        _settings = settings;
+        _authenticationStateProvider = authenticationStateProvider;
+        _userManager = userManager;
+        _extensionManager = extensionManager;
+        _appState = appState;
+        _languageService = languageService;
+    }
+
+    public async Task<Models.Content?> GetContentAsync(GetContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GenerateGetContentCacheKey(parameters, _dbContext);
+        if (parameters.Cached)
+        {
+            return await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await FetchContentAsync(parameters, cancellationToken));
+        }
+        return await FetchContentAsync(parameters, cancellationToken);
+    }
+
+    public async Task<HandlerResult<Models.Content>> SaveContentAsync(SaveContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var isUpdate = true;
+        var handlerResult = new HandlerResult<Models.Content>();
+
+        if (parameters.Content == null)
+        {
+            handlerResult.AddMessage("Content is null", ResultMessageType.Error);
+            return handlerResult;
+        }
+
+        var unpublishedContent = _dbContext.UnpublishedContent.FirstOrDefault(x => x.Id == parameters.Content.UnpublishedContentId);
+
+        if (parameters.SaveUnpublishedOnly)
+        {
+            var isNew = parameters.Content.UnpublishedContentId == null;
+            unpublishedContent ??= new UnpublishedContent();
+            _mapper.Map(parameters.Content, unpublishedContent.JsonContent);
+            unpublishedContent.JsonContent.PropertyData = parameters.Content.PropertyData;
+            unpublishedContent.JsonContent.UnpublishedContentId = unpublishedContent.Id;
+
+            if (isNew)
+            {
+                var dbContent = _dbContext.Contents.FirstOrDefault(x => parameters.Content.Id == x.Id);
+                if (dbContent != null)
+                {
+                    dbContent.UnpublishedContentId = unpublishedContent.Id;
+                }
+                _dbContext.UnpublishedContent.Add(unpublishedContent);
+            }
+
+            return await _dbContext.SaveChangesAndLog(null, handlerResult, _cacheService, _extensionManager, cancellationToken);
+        }
+
+        if (parameters.Content.Url.IsNullOrWhiteSpace())
+        {
+            var baseSlug = new SlugHelper().GenerateSlug(parameters.Content.Name);
+            parameters.Content.Url = GenerateUniqueUrl(_dbContext, baseSlug);
+        }
+
+        if (parameters.Content.ContentTypeAlias.IsNullOrWhiteSpace())
+        {
+            var contentType = _dbContext.ContentTypes.AsTracking()
+                .FirstOrDefault(x => x.Id == parameters.Content.ContentTypeId);
+            parameters.Content.ContentTypeAlias = contentType?.Alias;
+        }
+
+        var content = _dbContext.Contents
+            .Include(x => x.PropertyData)
+            .Include(x => x.ContentRoles).ThenInclude(x => x.Role)
+            .FirstOrDefault(x => x.Id == parameters.Content.Id);
+
+        if (content == null)
+        {
+            isUpdate = false;
+            content = parameters.Content;
+            content.LastUpdatedById = user!.Id;
+            _dbContext.Contents.Add(content);
+        }
+        else
+        {
+            _mapper.Map(parameters.Content, content);
+            content.LastUpdatedById = user!.Id;
+            content.DateUpdated = DateTime.UtcNow;
+
+            if (!parameters.ExcludePropertyData)
+            {
+                UpdateContentPropertyValues(content, parameters.Content.PropertyData);
+            }
+        }
+
+        if (parameters.UpdateContentRoles)
+        {
+            UpdateContentRoles(content, parameters);
+        }
+
+        if (unpublishedContent != null)
+        {
+            _dbContext.UnpublishedContent.Remove(unpublishedContent);
+        }
+
+        content.Path = content.BuildPath(_dbContext, isUpdate, _settings);
+
+        // Log audit without Mediator
+        if (user != null)
+        {
+            var nameText = content.Name ?? nameof(Models.Content);
+            var actionText = isUpdate ? "Updated" : "Created";
+            await SaveAuditAsync($"{user.Name} {actionText} {nameText}", cancellationToken);
+        }
+
+        return await _dbContext.SaveChangesAndLog(content, handlerResult, _cacheService, _extensionManager, cancellationToken);
+    }
+
+    public async Task<PaginatedList<Models.Content>> QueryContentAsync(QueryContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = BuildQuery(parameters);
+        var cacheKey = query.GenerateCacheKey(typeof(Models.Content));
+        if (parameters.Cached)
+        {
+            return (await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await FetchContentAsync(parameters, cancellationToken)))!;
+        }
+        return await FetchContentAsync(parameters, cancellationToken);
+    }
+
+    public async Task<HandlerResult<Models.Content>> DeleteContentAsync(DeleteContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var loggedInUser = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<Models.Content>();
+
+        var content = _dbContext.Contents.FirstOrDefault(x => x.Id == parameters.ContentId);
+        if (content == null)
+        {
+            handlerResult.AddMessage("Unable to delete, as no Content with that id exists", ResultMessageType.Warning);
+            return handlerResult;
+        }
+
+        if (parameters.MoveToRecycleBin)
+        {
+            content.Deleted = true;
+            await SaveAuditIfUser(loggedInUser, content.Name, "Recycle Binned", cancellationToken);
+        }
+        else
+        {
+            var children = _dbContext.Contents.AsNoTracking().Where(x => x.ParentId == content.Id);
+            if (children.Any())
+            {
+                handlerResult.AddMessage("Unable to delete content with child content, delete or move those items first", ResultMessageType.Error);
+                return handlerResult;
+            }
+
+            var propertyDataToDelete = _dbContext.ContentPropertyValues.Where(x => x.ContentId == content.Id);
+            foreach (var contentPropertyValue in propertyDataToDelete)
+            {
+                _dbContext.ContentPropertyValues.Remove(contentPropertyValue);
+            }
+
+            if (content.UnpublishedContentId != null)
+            {
+                var uContent = _dbContext.UnpublishedContent.FirstOrDefault(x => x.Id == content.UnpublishedContentId);
+                if (uContent != null) _dbContext.UnpublishedContent.Remove(uContent);
+            }
+
+            content.PropertyData.Clear();
+            await SaveAuditIfUser(loggedInUser, content.Name, "Deleted", cancellationToken);
+            _dbContext.Contents.Remove(content);
+            await _appState.NotifyContentDeleted(null, authState.User.Identity?.Name!);
+        }
+
+        return await _dbContext.SaveChangesAndLog(content, handlerResult, _cacheService, _extensionManager, cancellationToken);
+    }
+
+    public async Task<HandlerResult<Models.Content>> CopyContentAsync(CopyContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<Models.Content>();
+
+        var contentToCopy = await _dbContext.Contents
+            .AsNoTracking()
+            .Include(content => content.PropertyData)
+            .FirstOrDefaultAsync(x => x.Id == parameters.ContentToCopy, cancellationToken);
+
+        if (contentToCopy == null)
+        {
+            handlerResult.Success = false;
+            handlerResult.AddMessage("Unable to copy, as no Content with that ID exists", ResultMessageType.Error);
+            return handlerResult;
+        }
+
+        var idMap = new Dictionary<Guid, Guid>();
+        var newParentId = parameters.CopyTo ?? contentToCopy.ParentId;
+        var copiedContent = CreateCopy(contentToCopy, user, newParentId);
+
+        idMap[contentToCopy.Id] = copiedContent.Id;
+
+        if (newParentId.HasValue)
+        {
+            var parentContent = await _dbContext.Contents.AsNoTracking().FirstOrDefaultAsync(x => x.Id == newParentId, cancellationToken);
+            if (parentContent != null)
+            {
+                copiedContent.Path = [.. parentContent.Path, copiedContent.Id];
+            }
+        }
+        else
+        {
+            copiedContent.Path = [copiedContent.Id];
+        }
+
+        _dbContext.Add(copiedContent);
+
+        if (parameters.IncludeDescendants)
+        {
+            var descendants = await _dbContext.Contents
+                .WherePathLike(contentToCopy.Id)
+                .AsNoTracking()
+                .Include(content => content.PropertyData)
+                .ToListAsync(cancellationToken);
+
+            foreach (var descendant in descendants.Where(x => x.Id != contentToCopy.Id))
+            {
+                if (descendant.ParentId != null)
+                {
+                    var newParentIdForDescendant = idMap[descendant.ParentId.Value];
+                    var copiedDescendant = CreateCopy(descendant, user, newParentIdForDescendant);
+                    copiedDescendant.Path = descendant.Path.Select(id => idMap.TryGetValue(id, out var value) ? value : id).ToList();
+                    idMap[descendant.Id] = copiedDescendant.Id;
+                    _dbContext.Add(copiedDescendant);
+                }
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        if (user != null)
+        {
+            await SaveAuditAsync($"{user.Name} Copied {contentToCopy.Name}", cancellationToken);
+        }
+
+        handlerResult.Success = true;
+        handlerResult.AddMessage("Content copied successfully.", ResultMessageType.Success);
+        return handlerResult;
+
+        Models.Content CreateCopy(Models.Content original, User? currentUser, Guid? parentId = null)
+        {
+            var copy = _mapper.Map<Models.Content>(original);
+            copy.Id = Guid.NewGuid();
+            copy.Name = original.Name + " (Copy)";
+            copy.Url = original.Url + "-copy";
+            copy.LastUpdatedById = currentUser?.Id;
+            copy.ParentId = parentId;
+            copy.DateCreated = DateTime.UtcNow;
+            copy.DateUpdated = DateTime.UtcNow;
+            copy.Path = [];
+            copy.Published = false;
+            copy.Deleted = false;
+            copy.PropertyData = original.PropertyData.Select(p => new ContentPropertyValue
+            {
+                Id = Guid.NewGuid(),
+                DateUpdated = p.DateUpdated,
+                DateCreated = p.DateCreated,
+                ContentTypePropertyId = p.ContentTypePropertyId,
+                Value = p.Value,
+                ContentId = p.ContentId,
+                Alias = p.Alias
+            }).ToList();
+            return copy;
+        }
+    }
+
+    public async Task<EntryModel> GetContentFromRequestAsync(GetContentFromRequestParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GenerateGetContentFromRequestCacheKey(parameters);
+        return (await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await FetchEntryModelAsync(parameters, cancellationToken), 0, 5))!;
+    }
+
+    public async Task<ContentType?> GetContentTypeAsync(GetContentTypeParameters parameters, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.ContentTypes.FirstOrDefaultAsync(x => x.Id == parameters.Id, cancellationToken: cancellationToken);
+    }
+
+    public async Task<HandlerResult<ContentType>> SaveContentTypeAsync(SaveContentTypeParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<ContentType>();
+        var isUpdate = false;
+
+        if (parameters.ContentType == null)
+        {
+            handlerResult.AddMessage("ContentType is null", ResultMessageType.Error);
+            return handlerResult;
+        }
+
+        if (parameters.ContentType.Alias.IsNullOrWhiteSpace())
+        {
+            parameters.ContentType.Alias = parameters.ContentType.Name.ToAlias();
+        }
+
+        var contentType = _dbContext.ContentTypes.FirstOrDefault(x => x.Id == parameters.ContentType.Id);
+        if (contentType == null)
+        {
+            var containsAlias = _dbContext.ContentTypes.Any(x => x.Alias == parameters.ContentType.Alias);
+            if (containsAlias)
+            {
+                handlerResult.AddMessage("Content Type Alias already exists, change the content type name", ResultMessageType.Error);
+                return handlerResult;
+            }
+
+            contentType = parameters.ContentType;
+            contentType.LastUpdatedById = user!.Id;
+            _dbContext.ContentTypes.Add(contentType);
+        }
+        else
+        {
+            isUpdate = true;
+            _mapper.Map(parameters.ContentType, contentType);
+            contentType.LastUpdatedById = user!.Id;
+            contentType.DateUpdated = DateTime.UtcNow;
+        }
+
+        if (user != null)
+        {
+            var actionText = isUpdate ? "Updated" : "Created";
+            await SaveAuditAsync($"{user.Name} {actionText} {contentType.Name}", cancellationToken);
+        }
+
+        return await _dbContext.SaveChangesAndLog(contentType, handlerResult, _cacheService, _extensionManager, cancellationToken);
+    }
+
+    public Task<PaginatedList<ContentType>> QueryContentTypesAsync(QueryContentTypesParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.ContentTypes.AsQueryable();
+
+        if (parameters.AsNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        if (parameters.Ids.Count != 0)
+        {
+            query = query.Where(x => parameters.Ids.Contains(x.Id));
+        }
+
+        if (!parameters.SearchTerm.IsNullOrWhiteSpace())
+        {
+            query = query.Where(x => x.Name != null && x.Name.ToLower().Contains(parameters.SearchTerm.ToLower()));
+        }
+
+        if (parameters.OnlyElementTypes)
+        {
+            query = query.Where(x => x.IsElementType == true);
+        }
+        else if (!parameters.IncludeElementTypes)
+        {
+            query = query.Where(x => x.IsElementType == false);
+        }
+
+        if (parameters.OnlyCompositions)
+        {
+            query = query.Where(x => x.IsComposition == true);
+        }
+        else if (!parameters.IncludeCompositions)
+        {
+            query = query.Where(x => x.IsComposition == false);
+        }
+
+        if (parameters.RootOnly)
+        {
+            query = query.Where(x => x.AllowAtRoot);
+        }
+
+        if (parameters.OnlyFolders)
+        {
+            query = query.Where(x => x.IsFolder == true);
+        }
+        else if (!parameters.IncludeFolders)
+        {
+            query = query.Where(x => x.IsFolder == false);
+        }
+
+        if (parameters.ParentId != null)
+        {
+            query = query.Where(x => x.ParentId == parameters.ParentId);
+        }
+
+        query = parameters.OrderBy switch
+        {
+            GetContentTypesOrderBy.DateUpdated => query.OrderBy(p => p.DateUpdated),
+            GetContentTypesOrderBy.DateUpdatedDescending => query.OrderByDescending(p => p.DateUpdated),
+            GetContentTypesOrderBy.DateCreated => query.OrderBy(p => p.DateCreated),
+            GetContentTypesOrderBy.DateCreatedDescending => query.OrderByDescending(p => p.DateCreated),
+            GetContentTypesOrderBy.Name => query.OrderBy(p => p.Name),
+            _ => query.OrderByDescending(p => p.DateUpdated)
+        };
+
+        return Task.FromResult(query.ToPaginatedList(parameters.PageIndex, parameters.AmountPerPage));
+    }
+
+    public async Task<HandlerResult<ContentType>> DeleteContentTypeAsync(DeleteContentTypeParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<ContentType>();
+
+        var contentUsingContentType = await QueryContentAsync(new QueryContentParameters { ContentTypeId = parameters.ContentTypeId }, cancellationToken);
+        if (contentUsingContentType.Items.Any())
+        {
+            handlerResult.Success = false;
+            handlerResult.AddMessage("Unable to delete, because this ContentType is being used", ResultMessageType.Warning);
+            return handlerResult;
+        }
+
+        var children = await QueryContentTypesAsync(new QueryContentTypesParameters { ParentId = parameters.ContentTypeId }, cancellationToken);
+        if (children.Items.Any())
+        {
+            handlerResult.Success = false;
+            handlerResult.AddMessage("Unable to delete, because this ContentType has children", ResultMessageType.Warning);
+            return handlerResult;
+        }
+
+        var contentType = _dbContext.ContentTypes.FirstOrDefault(x => x.Id == parameters.ContentTypeId);
+        if (contentType != null)
+        {
+            if (contentType.IsComposition)
+            {
+                var anyUsingThisComposition = QueryContentTypesForComposition(parameters.ContentTypeId);
+                if (anyUsingThisComposition.Items.Any())
+                {
+                    handlerResult.Success = false;
+                    handlerResult.AddMessage("Unable to delete, because there are content types using this composition, remove it first", ResultMessageType.Warning);
+                    return handlerResult;
+                }
+            }
+
+            if (user != null)
+            {
+                await SaveAuditAsync($"{user.Name} Deleted {contentType.Name}", cancellationToken);
+            }
+
+            _dbContext.ContentTypes.Remove(contentType);
+            return await _dbContext.SaveChangesAndLog(contentType, handlerResult, _cacheService, _extensionManager, cancellationToken);
+        }
+
+        handlerResult.AddMessage("Unable to delete, as no ContentType with that id exists", ResultMessageType.Warning);
+        return handlerResult;
+    }
+
+    public async Task<Domain> GetDomainAsync(GetDomainParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Domains.AsQueryable();
+        if (parameters.AsNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        if (parameters.Url != null)
+        {
+            return await query.FirstOrDefaultAsync(x => x.Url == parameters.Url, cancellationToken: cancellationToken) ?? new Domain();
+        }
+
+        if (parameters.Id != null)
+        {
+            return await query.FirstOrDefaultAsync(x => x.Id == parameters.Id, cancellationToken: cancellationToken) ?? new Domain();
+        }
+
+        return await query.FirstOrDefaultAsync(cancellationToken: cancellationToken) ?? new Domain();
+    }
+
+    public async Task<HandlerResult<Domain>> SaveDomainAsync(SaveDomainParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<Domain>();
+        var isUpdate = false;
+
+        if (parameters.Domain == null)
+        {
+            handlerResult.AddMessage("Domain is null", ResultMessageType.Error);
+            return handlerResult;
+        }
+
+        var domain = _dbContext.Domains.FirstOrDefault(x => x.Id == parameters.Domain.Id);
+        if (domain == null)
+        {
+            domain = parameters.Domain;
+            _dbContext.Domains.Add(domain);
+        }
+        else
+        {
+            isUpdate = true;
+            _mapper.Map(parameters.Domain, domain);
+            domain.DateUpdated = DateTime.UtcNow;
+        }
+
+        if (user != null)
+        {
+            var actionText = isUpdate ? "Updated" : "Created";
+            await SaveAuditAsync($"{user.Name} {actionText} Domain ({domain.Url})", cancellationToken);
+        }
+
+        return await _dbContext.SaveChangesAndLog(domain, handlerResult, _cacheService, _extensionManager, cancellationToken);
+    }
+
+    public Task<PaginatedList<Domain>> QueryDomainAsync(QueryDomainParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Domains.AsQueryable();
+        if (parameters.AsNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        var idCount = parameters.Ids.Count;
+        if (idCount != 0)
+        {
+            query = query.Where(x => parameters.Ids.Contains(x.Id));
+            parameters.AmountPerPage = idCount;
+        }
+
+        if (parameters.ContentId != null)
+        {
+            query = query.Where(x => x.ContentId == parameters.ContentId);
+        }
+
+        if (parameters.LanguageId != null)
+        {
+            query = query.Where(x => x.LanguageId == parameters.LanguageId);
+        }
+
+        if (parameters.WhereClause != null)
+        {
+            query = query.Where(parameters.WhereClause);
+        }
+
+        query = parameters.OrderBy switch
+        {
+            GetDomainOrderBy.DateCreated => query.OrderBy(p => p.DateCreated),
+            GetDomainOrderBy.DateCreatedDescending => query.OrderByDescending(p => p.DateCreated),
+            GetDomainOrderBy.Url => query.OrderBy(p => p.Url),
+            _ => query.OrderByDescending(p => p.DateCreated)
+        };
+
+        return Task.FromResult(query.ToPaginatedList(parameters.PageIndex, parameters.AmountPerPage));
+    }
+
+    public async Task<HandlerResult<Domain?>> DeleteDomainAsync(DeleteDomainParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await _userManager.GetUserAsync(authState.User);
+        var handlerResult = new HandlerResult<Domain?>();
+
+        Domain? domain = null;
+        if (parameters.Id != null)
+        {
+            domain = await _dbContext.Domains.FirstOrDefaultAsync(x => x.Id == parameters.Id, cancellationToken: cancellationToken);
+        }
+        else if (parameters.ContentId != null)
+        {
+            domain = await _dbContext.Domains.FirstOrDefaultAsync(x => x.ContentId == parameters.ContentId, cancellationToken: cancellationToken);
+        }
+
+        if (domain != null)
+        {
+            if (user != null)
+            {
+                await SaveAuditAsync($"{user.Name} Deleted Domain ({domain.Url})", cancellationToken);
+            }
+            _dbContext.Domains.Remove(domain);
+            return await _dbContext.SaveChangesAndLog(domain, handlerResult, _cacheService, _extensionManager, cancellationToken);
+        }
+
+        handlerResult.AddMessage("Unable to delete, as no Domain with that id exists", ResultMessageType.Warning);
+        return handlerResult;
+    }
+
+    public async Task<bool> AnyContentAsync(AnyContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Contents.AsNoTracking().AnyAsync(cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> HasChildContentAsync(HasChildContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GenerateHasChildContentCacheKey(parameters);
+        if (parameters.Cached)
+        {
+            return await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await _dbContext.Contents.AsNoTracking().AnyAsync(c => c.ParentId == parameters.ParentId, cancellationToken: cancellationToken));
+        }
+        return await _dbContext.Contents.AsNoTracking().AnyAsync(c => c.ParentId == parameters.ParentId, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> HasChildContentTypeAsync(HasChildContentTypeParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GenerateHasChildContentTypeCacheKey(parameters);
+        if (parameters.Cached)
+        {
+            return await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await _dbContext.ContentTypes.AsNoTracking().AnyAsync(c => c.ParentId == parameters.ParentId, cancellationToken: cancellationToken));
+        }
+        return await _dbContext.ContentTypes.AsNoTracking().AnyAsync(c => c.ParentId == parameters.ParentId, cancellationToken: cancellationToken);
+    }
+
+    public async Task<Dictionary<object, string>> GetContentLanguagesAsync(GetContentLanguagesParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Contents.AsNoTracking()
+            .Include(x => x.Language)
+            .Select(c => new { c.Id, c.Url, c.Language })
+            .Where(x => x.Language != null && x.Url != null);
+
+        var queryString = query.ToQueryString();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(queryString));
+        var cacheKey = typeof(Models.Content).ToCacheKey(Convert.ToBase64String(hash));
+
+        return (await _cacheService.GetSetCachedItemAsync(cacheKey, async () =>
+        {
+            var contentLanguages = await query.ToListAsync(cancellationToken: cancellationToken);
+            var dict = new Dictionary<object, string>();
+            foreach (var c in contentLanguages)
+            {
+                dict.Add(c.Url!, c.Language!.LanguageIsoCode!);
+                dict.Add(c.Id, c.Language!.LanguageIsoCode!);
+            }
+            return dict;
+        }))!;
+    }
+
+    public async Task<List<Domain>> GetCachedDomainsAsync(CachedDomainsParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Domains.AsNoTracking().Include(x => x.Language);
+        var queryString = query.ToQueryString();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(queryString));
+        var cacheKey = typeof(Domain).ToCacheKey(Convert.ToBase64String(hash));
+        return (await _cacheService.GetSetCachedItemAsync(cacheKey, async () => await query.ToListAsync(cancellationToken: cancellationToken)))!;
+    }
+
+    public async Task<HandlerResult<UnpublishedContent>> ClearUnpublishedContentAsync(ClearUnpublishedContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var handlerResult = new HandlerResult<UnpublishedContent>();
+        var content = await _dbContext.Contents.FirstOrDefaultAsync(x => x.Id == parameters.ContentId, cancellationToken: cancellationToken);
+        if (content?.UnpublishedContentId != null)
+        {
+            var uContent = await _dbContext.UnpublishedContent.FirstOrDefaultAsync(x => x.Id == content.UnpublishedContentId, cancellationToken: cancellationToken);
+            if (uContent != null) _dbContext.UnpublishedContent.Remove(uContent);
+            var result = (await _dbContext.SaveChangesAndLog(uContent, handlerResult, _cacheService, _extensionManager, cancellationToken))!;
+            return result;
+        }
+        return handlerResult;
+    }
+
+    public async Task<DataGridResult<Models.Content>> GetDataGridContentAsync(DataGridContentParameters parameters, CancellationToken cancellationToken = default)
+    {
+        var result = new DataGridResult<Models.Content>();
+        var query = _dbContext.Contents
+            .Include(x => x.ContentType)
+            .Include(x => x.LastUpdatedBy)
+            .Where(x => x.Deleted == false)
+            .AsQueryable();
+
+        if (parameters.IncludeChildren)
+        {
+            query = query.Include(x => x.Children).AsSplitQuery();
+        }
+
+        if (parameters.AsNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        if (!parameters.ContentTypeAlias.IsNullOrWhiteSpace())
+        {
+            var contentType = _dbContext.ContentTypes.AsNoTracking().FirstOrDefault(x => x.Alias == parameters.ContentTypeAlias);
+            if (contentType != null)
+            {
+                parameters.ContentTypeId = contentType.Id;
+            }
+        }
+
+        if (parameters.LastEditedBy != null)
+        {
+            query = query.Where(x => x.LastUpdatedById == parameters.LastEditedBy.Value);
+        }
+
+        if (parameters.ContentTypeId != null)
+        {
+            query = query.Where(x => x.ContentTypeId == parameters.ContentTypeId);
+        }
+
+        if (parameters.ParentId != null)
+        {
+            query = query.Where(x => x.ParentId == parameters.ParentId);
+        }
+
+        if (!string.IsNullOrEmpty(parameters.Filter))
+        {
+            query = query.Where(parameters.Filter);
+        }
+
+        if (!string.IsNullOrEmpty(parameters.Order))
+        {
+            query = query.OrderBy(parameters.Order);
+        }
+        else
+        {
+            query = parameters.OrderBy switch
+            {
+                GetContentsOrderBy.DateUpdated => query.OrderBy(p => p.DateUpdated),
+                GetContentsOrderBy.DateUpdatedDescending => query.OrderByDescending(p => p.DateUpdated),
+                GetContentsOrderBy.DateCreated => query.OrderBy(p => p.DateCreated),
+                GetContentsOrderBy.DateCreatedDescending => query.OrderByDescending(p => p.DateCreated),
+                GetContentsOrderBy.SortOrder => query.OrderBy(p => p.SortOrder),
+                _ => query.OrderByDescending(p => p.DateUpdated)
+            };
+        }
+
+        result.Count = query.Count();
+        result.Items = await query.Skip(parameters.Skip).Take(parameters.Take).ToListAsync(cancellationToken: cancellationToken);
+        return result;
+    }
+
+    // Helpers
+    private static string GenerateGetContentCacheKey(GetContentParameters request, IZauberDbContext dbContext)
+    {
+        var query = BuildQuery(request, dbContext);
+        var queryString = query.ToQueryString();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(queryString));
+        return typeof(Models.Content).ToCacheKey(Convert.ToBase64String(hash));
+    }
+
+    private static IQueryable<Models.Content> BuildQuery(GetContentParameters request, IZauberDbContext dbContext)
+    {
+        var query = dbContext.Contents
+            .Include(x => x.ContentType)
+            .Include(x => x.PropertyData)
+            .AsSplitQuery()
+            .AsQueryable();
+
+        if (request.AsNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        if (!request.IncludeUnpublished)
+        {
+            query = query.Where(x => x.Published);
+        }
+
+        if (request.IncludeUnpublishedContent)
+        {
+            query = query.Include(x => x.UnpublishedContent);
+        }
+
+        if (request.IncludeParent)
+        {
+            query = query.Include(x => x.Parent);
+        }
+
+        if (request.IncludeChildren)
+        {
+            query = request.IncludeUnpublished ? query.Include(x => x.Children)
+                : query.Include(x => x.Children.Where(c => c.Published));
+            query = query.AsSplitQuery();
+        }
+
+        if (request.IncludeContentRoles)
+        {
+            query = query.Include(x => x.ContentRoles).ThenInclude(x => x.Role).AsSplitQuery();
+        }
+
+        if (request.Id != null)
+        {
+            return query.Where(x => x.Id == request.Id);
+        }
+
+        if (!request.ContentTypeAlias.IsNullOrWhiteSpace())
+        {
+            return query.Where(x => x.ContentType != null && x.ContentType.Alias == request.ContentTypeAlias);
+        }
+
+        return query;
+    }
+
+    private IQueryable<Models.Content> BuildQuery(QueryContentParameters request)
+    {
+        var query = _dbContext.Contents.Include(x => x.ContentType)
+            .Include(x => x.PropertyData).AsSplitQuery().AsQueryable();
+
+        if (request.Query != null)
+        {
+            query = request.Query.Invoke();
+        }
+        else
+        {
+            if (request.IncludeContentRoles)
+            {
+                query = query.Include(x => x.ContentRoles);
+            }
+
+            if (request.OnlyUnpublished)
+            {
+                query = query.Include(x => x.UnpublishedContent);
+                query = query.Where(x => x.UnpublishedContentId != null || x.Published == false);
+            }
+            else
+            {
+                query = !request.IncludeUnpublished ? query.Where(x => x.Published) : query.Include(x => x.UnpublishedContent);
+            }
+
+            if (request.IsDeleted != null)
+            {
+                query = query.Where(x => x.Deleted == request.IsDeleted);
+            }
+
+            if (request.IncludeChildren)
+            {
+                query = request.IncludeUnpublished ? query.Include(x => x.Children)
+                        .ThenInclude(x => x.UnpublishedContent)
+                    : query.Include(x => x.Children.Where(c => c.Published));
+            }
+
+            if (request.RootContentOnly)
+            {
+                query = query.Where(x => x.ParentId == null);
+            }
+
+            if (request.TagSlugs.Any())
+            {
+                query = (from content in query
+                        join tagItem in _dbContext.TagItems on content.Id equals tagItem.ItemId
+                        join tag in _dbContext.Tags on tagItem.TagId equals tag.Id
+                        where request.TagSlugs.Contains(tag.Slug)
+                        select content)
+                    .Distinct();
+            }
+
+            if (request.AsNoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.SearchTerm))
+            {
+                query = query.Where(x => x.Name != null && x.Name.ToLower().Contains(request.SearchTerm.ToLower()));
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.ContentTypeAlias))
+            {
+                var contentType = _dbContext.ContentTypes.AsNoTracking().FirstOrDefault(x => x.Alias == request.ContentTypeAlias);
+                request.ContentTypeId = contentType?.Id ?? Guid.Empty;
+            }
+
+            if (request.ContentTypeId != null)
+            {
+                query = query.Where(x => x.ContentTypeId == request.ContentTypeId);
+            }
+
+            if (request.ParentId != null)
+            {
+                query = query.Where(x => x.ParentId == request.ParentId);
+            }
+
+            var idCount = request.Ids.Count;
+            if (idCount != 0)
+            {
+                query = query.Where(x => request.Ids.Contains(x.Id));
+                request.AmountPerPage = idCount;
+            }
+        }
+
+        if (request.WhereClause != null)
+        {
+            query = query.Where(request.WhereClause);
+        }
+
+        query = request.OrderBy switch
+        {
+            GetContentsOrderBy.DateUpdated => query.OrderBy(p => p.DateUpdated),
+            GetContentsOrderBy.DateUpdatedDescending => query.OrderByDescending(p => p.DateUpdated),
+            GetContentsOrderBy.DateCreated => query.OrderBy(p => p.DateCreated),
+            GetContentsOrderBy.DateCreatedDescending => query.OrderByDescending(p => p.DateCreated),
+            GetContentsOrderBy.SortOrder => query.OrderBy(p => p.SortOrder),
+            _ => query.OrderByDescending(p => p.DateUpdated)
+        };
+
+        return query;
+    }
+
+    private Task<PaginatedList<Models.Content>> FetchContentAsync(QueryContentParameters request, CancellationToken cancellationToken)
+    {
+        var query = BuildQuery(request);
+        return Task.FromResult(query.ToPaginatedList(request.PageIndex, request.AmountPerPage));
+    }
+
+    private async Task<Models.Content?> FetchContentAsync(GetContentParameters request, CancellationToken cancellationToken)
+    {
+        var query = BuildQuery(request, _dbContext);
+        return await query.FirstOrDefaultAsync(cancellationToken: cancellationToken);
+    }
+
+    private async Task<EntryModel> FetchEntryModelAsync(GetContentFromRequestParameters request, CancellationToken cancellationToken)
+    {
+        var entryModel = new EntryModel();
+        var contentQueryable = _dbContext.Contents.AsNoTracking().Include(x => x.ContentType);
+
+        var domains = await GetCachedDomainsAsync(new CachedDomainsParameters(), cancellationToken);
+        var contentWithLanguages = await GetContentLanguagesAsync(new GetContentLanguagesParameters(), cancellationToken);
+
+        var matchedDomain = MatchDomainWithContent(request.Url ?? string.Empty, domains);
+
+        var content = request.IsRootContent
+            ? matchedDomain != null
+                ? await contentQueryable.Select(c => new { c.Id, c.InternalRedirectId, c.ContentType!.IncludeChildren, c.Path })
+                    .FirstOrDefaultAsync(x => x.Id == matchedDomain.ContentId, cancellationToken)
+                : await contentQueryable.Where(c => c.IsRootContent && c.Published)
+                    .Select(c => new { c.Id, c.InternalRedirectId, c.ContentType!.IncludeChildren, c.Path })
+                    .FirstOrDefaultAsync(cancellationToken)
+            : await contentQueryable.Where(c => c.Url == request.Slug && c.Published)
+                .Select(c => new { c.Id, c.InternalRedirectId, c.ContentType!.IncludeChildren, c.Path })
+                .FirstOrDefaultAsync(cancellationToken);
+
+        if (content?.InternalRedirectId != null && content.InternalRedirectId != Guid.Empty)
+        {
+            var internalRedirectIdValue = content.InternalRedirectId.Value;
+            content = await contentQueryable.Where(c => c.Id == internalRedirectIdValue)
+                .Select(c => new { c.Id, c.InternalRedirectId, c.ContentType!.IncludeChildren, c.Path })
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        if (content == null)
+        {
+            return entryModel;
+        }
+
+        var query = _dbContext.Contents.AsNoTracking().AsSplitQuery()
+            .Include(x => x.PropertyData)
+            .Include(x => x.Parent)
+            .Include(x => x.ContentType)
+            .Include(x => x.Language)
+            .Include(x => x.ContentRoles).ThenInclude(x => x.Role)
+            .AsQueryable();
+
+        if (request.IncludeChildren || content.IncludeChildren)
+        {
+            query = query.Include(x => x.Children);
+        }
+
+        var fullContent = await query.FirstOrDefaultAsync(c => c.Id == content.Id, cancellationToken: cancellationToken);
+        entryModel.Content = fullContent;
+
+        string? languageIsoCode = null;
+        if (matchedDomain?.Language?.LanguageIsoCode != null)
+        {
+            languageIsoCode = matchedDomain.Language.LanguageIsoCode;
+        }
+        else if (contentWithLanguages.TryGetValue(request.Slug ?? string.Empty, out var contentLanguage))
+        {
+            languageIsoCode = contentLanguage;
+        }
+
+        if (languageIsoCode.IsNullOrWhiteSpace())
+        {
+            foreach (var guid in content.Path)
+            {
+                if (contentWithLanguages.TryGetValue(guid, out var language))
+                {
+                    languageIsoCode = language;
+                    break;
+                }
+            }
+
+            if (languageIsoCode.IsNullOrWhiteSpace())
+            {
+                languageIsoCode = _settings.Value.AdminDefaultLanguage;
+            }
+        }
+
+        entryModel.LanguageIsoCode = languageIsoCode;
+        var allLanguageData = await _languageService.GetCachedAllLanguageDictionariesAsync(new ZauberCMS.Core.Languages.Parameters.GetCachedAllLanguageDictionariesParameters(), cancellationToken);
+        if (allLanguageData.TryGetValue(languageIsoCode, out var lng) && lng != null)
+        {
+            entryModel.LanguageKeys = lng;
+        }
+
+        return entryModel;
+    }
+
+    private static string GenerateGetContentFromRequestCacheKey(GetContentFromRequestParameters request)
+    {
+        var keyBuilder = new StringBuilder();
+        keyBuilder.Append($"GetContentFromRequest-");
+        keyBuilder.Append($"Url:{request.Url ?? "null"}-");
+        keyBuilder.Append($"Slug:{request.Slug ?? "null"}-");
+        keyBuilder.Append($"IsRoot:{request.IsRootContent}-");
+        keyBuilder.Append($"IncludeChildren:{request.IncludeChildren}");
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(keyBuilder.ToString()));
+        return typeof(Models.Content).ToCacheKey(Convert.ToBase64String(hash));
+    }
+
+    private static Domain? MatchDomainWithContent(string url, List<Domain> domains)
+    {
+        var uri = new Uri(url);
+        var requestHost = uri.Host.ToLower();
+        var requestPath = uri.AbsolutePath.TrimStart('/').ToLower();
+        return domains.FirstOrDefault(domain =>
+        {
+            var domainUrl = domain.Url?.ToLower();
+            if (domainUrl != null && domainUrl.Contains('/'))
+            {
+                var parts = domainUrl.Split('/', 2);
+                var domainHost = parts[0];
+                var domainPath = parts.Length > 1 ? parts[1] : string.Empty;
+                return requestHost == domainHost && requestPath.StartsWith(domainPath);
+            }
+            return requestHost == domainUrl;
+        });
+    }
+
+    private static string GenerateHasChildContentCacheKey(HasChildContentParameters request)
+    {
+        var key = $"HasChild-{request.ParentId}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        return typeof(Models.Content).ToCacheKey(Convert.ToBase64String(hash));
+    }
+
+    private static string GenerateHasChildContentTypeCacheKey(HasChildContentTypeParameters request)
+    {
+        var key = $"HasContentTypeChild-{request.ParentId}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        return typeof(ContentType).ToCacheKey(Convert.ToBase64String(hash));
+    }
+
+    private static string GenerateUniqueUrl(IZauberDbContext dbContext, string baseSlug)
+    {
+        var url = baseSlug;
+        if (!dbContext.Contents.Any(c => c.Url == url))
+        {
+            return url;
+        }
+
+        var counter = 1;
+        while (dbContext.Contents.Any(c => c.Url == url))
+        {
+            url = $"{baseSlug}-{counter}";
+            counter++;
+        }
+        return url;
+    }
+
+    private void UpdateContentRoles(Models.Content content, SaveContentParameters request)
+    {
+        var existingRoles = _dbContext.ContentRoles.Where(r => r.ContentId == content.Id).ToList();
+        var rolesToRemove = existingRoles.Where(er => request.Roles.All(rr => rr.Id != er.RoleId)).ToList();
+        if (rolesToRemove.Count != 0)
+        {
+            _dbContext.ContentRoles.RemoveRange(rolesToRemove);
+        }
+        var rolesToAdd = request.Roles.Where(rr => existingRoles.All(er => er.RoleId != rr.Id)).ToList();
+        if (rolesToAdd.Count != 0)
+        {
+            foreach (var role in rolesToAdd)
+            {
+                var contentRole = new ContentRole { ContentId = content.Id, RoleId = role.Id };
+                _dbContext.ContentRoles.Add(contentRole);
+            }
+        }
+    }
+
+    private void UpdateContentPropertyValues(Models.Content content, List<ContentPropertyValue> newPropertyValues)
+    {
+        var deletedItems = content.PropertyData.Where(epv => newPropertyValues.All(npv => npv.Id != epv.Id)).ToList();
+        foreach (var deletedItem in deletedItems)
+        {
+            _dbContext.ContentPropertyValues.Remove(deletedItem);
+        }
+
+        foreach (var newPropertyValue in newPropertyValues)
+        {
+            var existingPropertyValue = content.PropertyData.FirstOrDefault(epv => epv.Id == newPropertyValue.Id);
+            if (existingPropertyValue == null)
+            {
+                _dbContext.ContentPropertyValues.Add(newPropertyValue);
+            }
+            else
+            {
+                _mapper.Map(newPropertyValue, existingPropertyValue);
+            }
+        }
+    }
+
+    private PaginatedList<ContentType> QueryContentTypesForComposition(Guid compositionId)
+    {
+        var query = _dbContext.ContentTypes.WhereHasCompositionsUsing(compositionId);
+        return query.ToPaginatedList(1, int.MaxValue);
+    }
+
+    private async Task SaveAuditIfUser(User? user, string? name, string action, CancellationToken cancellationToken)
+    {
+        if (user == null) return;
+        await SaveAuditAsync($"{user.Name} {action} {name ?? string.Empty}", cancellationToken);
+    }
+
+    private async Task SaveAuditAsync(string description, CancellationToken cancellationToken)
+    {
+        // Inline minimal audit creation to avoid Mediator usage in services
+        _dbContext.Audits.Add(new ZauberCMS.Core.Audit.Models.Audit { Description = description });
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/ZauberCMS.Core/Data/Interfaces/IDataService.cs
+++ b/ZauberCMS.Core/Data/Interfaces/IDataService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Data.Models;
+using ZauberCMS.Core.Data.Parameters;
+using ZauberCMS.Core.Shared.Interfaces;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Data.Interfaces;
+
+public interface IDataService
+{
+    Task<GlobalData?> GetGlobalDataAsync(GetGlobalDataParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<GlobalData>> SaveGlobalDataAsync(SaveGlobalDataParameters parameters, CancellationToken cancellationToken = default);
+    Task<Dictionary<string, IEnumerable<object>>> MultiQueryAsync(MultiQueryParameters parameters, CancellationToken cancellationToken = default);
+    Task<DataGridResult<T>> GetDataGridAsync<T>(DataGridParameters<T> parameters, CancellationToken cancellationToken = default) where T : class, ITreeItem;
+}

--- a/ZauberCMS.Core/Data/Parameters/DataGridParameters.cs
+++ b/ZauberCMS.Core/Data/Parameters/DataGridParameters.cs
@@ -1,0 +1,12 @@
+using ZauberCMS.Core.Shared.Interfaces;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Data.Parameters;
+
+public class DataGridParameters<T> where T : class, ITreeItem
+{
+    public int Skip { get; set; }
+    public int Take { get; set; } = 20;
+    public string? OrderBy { get; set; }
+    public string? Filter { get; set; }
+}

--- a/ZauberCMS.Core/Data/Parameters/GetGlobalDataParameters.cs
+++ b/ZauberCMS.Core/Data/Parameters/GetGlobalDataParameters.cs
@@ -1,0 +1,7 @@
+namespace ZauberCMS.Core.Data.Parameters;
+
+public class GetGlobalDataParameters
+{
+    public string? Alias { get; set; }
+    public bool Cached { get; set; } = true;
+}

--- a/ZauberCMS.Core/Data/Parameters/MultiQueryParameters.cs
+++ b/ZauberCMS.Core/Data/Parameters/MultiQueryParameters.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using ZauberCMS.Core.Data.Interfaces;
+
+namespace ZauberCMS.Core.Data.Parameters;
+
+public class MultiQueryParameters
+{
+    public List<IQueryModel> Queries { get; set; } = [];
+}

--- a/ZauberCMS.Core/Data/Parameters/SaveGlobalDataParameters.cs
+++ b/ZauberCMS.Core/Data/Parameters/SaveGlobalDataParameters.cs
@@ -1,0 +1,7 @@
+namespace ZauberCMS.Core.Data.Parameters;
+
+public class SaveGlobalDataParameters
+{
+    public string? Alias { get; set; }
+    public string? Data { get; set; }
+}

--- a/ZauberCMS.Core/Email/Interfaces/IEmailService.cs
+++ b/ZauberCMS.Core/Email/Interfaces/IEmailService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Email.Parameters;
+
+namespace ZauberCMS.Core.Email.Interfaces;
+
+public interface IEmailService
+{
+    Task SendEmailConfirmationAsync(SendEmailConfirmationParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Email/Parameters/SendEmailConfirmationParameters.cs
+++ b/ZauberCMS.Core/Email/Parameters/SendEmailConfirmationParameters.cs
@@ -1,0 +1,10 @@
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Email.Parameters;
+
+public class SendEmailConfirmationParameters
+{
+    public User? User { get; set; }
+    public string? NewEmailAddress { get; set; }
+    public string? ReturnUrl { get; set; } = "/";
+}

--- a/ZauberCMS.Core/Languages/Interfaces/ILanguageService.cs
+++ b/ZauberCMS.Core/Languages/Interfaces/ILanguageService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Languages.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Interfaces;
+
+public interface ILanguageService
+{
+    Task<Language> GetLanguageAsync(GetLanguageParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Language>> SaveLanguageAsync(SaveLanguageParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Language>> QueryLanguageAsync(QueryLanguageParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Language?>> DeleteLanguageAsync(DeleteLanguageParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<HandlerResult<LanguageDictionary>> SaveLanguageDictionaryAsync(SaveLanguageDictionaryParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<LanguageDictionary?>> DeleteLanguageDictionaryAsync(DeleteLanguageDictionaryParameters parameters, CancellationToken cancellationToken = default);
+    Task<Dictionary<string, Dictionary<string, string>>> GetCachedAllLanguageDictionariesAsync(GetCachedAllLanguageDictionariesParameters parameters, CancellationToken cancellationToken = default);
+    Task<DataGridResult<LanguageDictionary>> GetDataGridLanguageDictionaryAsync(DataGridLanguageDictionaryParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Languages/Parameters/DataGridLanguageDictionaryParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/DataGridLanguageDictionaryParameters.cs
@@ -1,0 +1,11 @@
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class DataGridLanguageDictionaryParameters
+{
+    public int Skip { get; set; }
+    public int Take { get; set; } = 20;
+    public string? Order { get; set; }
+    public string? Filter { get; set; }
+}

--- a/ZauberCMS.Core/Languages/Parameters/DeleteLanguageDictionaryParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/DeleteLanguageDictionaryParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class DeleteLanguageDictionaryParameters
+{
+    public Guid? Id { get; set; }
+}

--- a/ZauberCMS.Core/Languages/Parameters/DeleteLanguageParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/DeleteLanguageParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class DeleteLanguageParameters
+{
+    public Guid? Id { get; set; }
+    public string? LanguageIsoCode { get; set; }
+}

--- a/ZauberCMS.Core/Languages/Parameters/GetCachedAllLanguageDictionariesParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/GetCachedAllLanguageDictionariesParameters.cs
@@ -1,0 +1,5 @@
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class GetCachedAllLanguageDictionariesParameters
+{
+}

--- a/ZauberCMS.Core/Languages/Parameters/GetLanguageParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/GetLanguageParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Languages.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class GetLanguageParameters
+{
+    public Guid? Id { get; set; }
+    public bool AsNoTracking { get; set; }
+    public string? LanguageIsoCode { get; set; }
+}

--- a/ZauberCMS.Core/Languages/Parameters/QueryLanguageParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/QueryLanguageParameters.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class QueryLanguageParameters
+{
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public bool IncludeChildren { get; set; }
+    public List<string> LanguageIsoCodes { get; set; } = [];
+    public GetLanguageOrderBy OrderBy { get; set; } = GetLanguageOrderBy.DateCreatedDescending;
+    public Expression<Func<Language, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Language>>? Query { get; set; }
+}
+
+public enum GetLanguageOrderBy
+{
+    DateCreated,
+    DateCreatedDescending,
+    LanguageIsoCode,
+    LanguageCultureName
+}

--- a/ZauberCMS.Core/Languages/Parameters/SaveLanguageDictionaryParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/SaveLanguageDictionaryParameters.cs
@@ -1,0 +1,9 @@
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class SaveLanguageDictionaryParameters
+{
+    public LanguageDictionary? LanguageDictionary { get; set; }
+}

--- a/ZauberCMS.Core/Languages/Parameters/SaveLanguageParameters.cs
+++ b/ZauberCMS.Core/Languages/Parameters/SaveLanguageParameters.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Globalization;
+using ZauberCMS.Core.Languages.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Languages.Parameters;
+
+public class SaveLanguageParameters
+{
+    public CultureInfo? CultureInfo { get; set; }
+    public Guid? Id { get; set; }
+}

--- a/ZauberCMS.Core/Media/Interfaces/IMediaService.cs
+++ b/ZauberCMS.Core/Media/Interfaces/IMediaService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Media.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Media.Interfaces;
+
+public interface IMediaService
+{
+    Task<Models.Media?> GetMediaAsync(GetMediaParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Models.Media>> SaveMediaAsync(SaveMediaParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Models.Media>> QueryMediaAsync(QueryMediaParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Models.Media>> DeleteMediaAsync(DeleteMediaParameters parameters, CancellationToken cancellationToken = default);
+    Task<bool> HasChildMediaAsync(HasChildMediaParameters parameters, CancellationToken cancellationToken = default);
+    Task<Dictionary<string, Guid>> GetRestrictedMediaUrlsAsync(GetRestrictedMediaUrlsParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Media/Parameters/DeleteMediaParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/DeleteMediaParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class DeleteMediaParameters
+{
+    public Guid MediaId { get; set; }
+    public bool DeleteFile { get; set; }
+}

--- a/ZauberCMS.Core/Media/Parameters/GetMediaParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/GetMediaParameters.cs
@@ -1,0 +1,14 @@
+using System;
+using ZauberCMS.Core.Media.Models;
+
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class GetMediaParameters
+{
+    public Guid? Id { get; set; }
+    public bool IncludeChildren { get; set; }
+    public bool IncludeParent { get; set; }
+    public bool Cached { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public MediaType? MediaType { get; set; }
+}

--- a/ZauberCMS.Core/Media/Parameters/GetRestrictedMediaUrlsParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/GetRestrictedMediaUrlsParameters.cs
@@ -1,0 +1,6 @@
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class GetRestrictedMediaUrlsParameters
+{
+    public bool Cached { get; set; } = true;
+}

--- a/ZauberCMS.Core/Media/Parameters/HasChildMediaParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/HasChildMediaParameters.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class HasChildMediaParameters
+{
+    public Guid ParentId { get; set; }
+}

--- a/ZauberCMS.Core/Media/Parameters/QueryMediaParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/QueryMediaParameters.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Media.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class QueryMediaParameters
+{
+    public bool Cached { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public bool IncludeChildren { get; set; }
+    public List<MediaType> MediaTypes { get; set; } = [];
+    public GetMediaOrderBy OrderBy { get; set; } = GetMediaOrderBy.DateUpdatedDescending;
+    public Expression<Func<Media.Models.Media, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Media.Models.Media>>? Query { get; set; }
+}
+
+public enum GetMediaOrderBy
+{
+    DateUpdated,
+    DateUpdatedDescending,
+    DateCreated,
+    DateCreatedDescending,
+    Name,
+    NameDescending
+}

--- a/ZauberCMS.Core/Media/Parameters/SaveMediaParameters.cs
+++ b/ZauberCMS.Core/Media/Parameters/SaveMediaParameters.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Components.Forms;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Media.Parameters;
+
+public class SaveMediaParameters
+{
+    public IBrowserFile? FileToSave { get; set; }
+    public Media.Models.Media? MediaToSave { get; set; }
+    public Guid? ParentFolderId { get; set; }
+    public bool IsUpdate { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Interfaces/IMembershipService.cs
+++ b/ZauberCMS.Core/Membership/Interfaces/IMembershipService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Membership.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Interfaces;
+
+public interface IMembershipService
+{
+    Task<User?> GetUserAsync(GetUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<User>> SaveUserAsync(SaveUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<User>> CreateUpdateUserAsync(CreateUpdateUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<User>> DeleteUserAsync(DeleteUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<User>> QueryUsersAsync(QueryUsersParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<Role?> GetRoleAsync(GetRoleParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Role>> SaveRoleAsync(SaveRoleParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Role>> DeleteRoleAsync(DeleteRoleParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Role>> QueryRolesAsync(QueryRolesParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<AuthenticationResult> LoginUserAsync(LoginUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<AuthenticationResult> RegisterUserAsync(RegisterUserParameters parameters, CancellationToken cancellationToken = default);
+    Task<AuthenticationResult> ExternalLoginAsync(ExternalLoginParameters parameters, CancellationToken cancellationToken = default);
+    Task<AuthenticationResult> ConfirmEmailAsync(ConfirmEmailParameters parameters, CancellationToken cancellationToken = default);
+    Task<AuthenticationResult> ForgotPasswordAsync(ForgotPasswordParameters parameters, CancellationToken cancellationToken = default);
+    Task<AuthenticationResult> ResetPasswordAsync(ResetPasswordParameters parameters, CancellationToken cancellationToken = default);
+    Task<User?> GetCurrentUserAsync(GetCurrentUserParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Membership/Parameters/ConfirmEmailParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/ConfirmEmailParameters.cs
@@ -1,0 +1,10 @@
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class ConfirmEmailParameters
+{
+    public string? UserId { get; set; }
+    public string? Code { get; set; }
+    public bool IsEmailUpdate { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/CreateUpdateUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/CreateUpdateUserParameters.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components.Forms;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class CreateUpdateUserParameters
+{
+    public string? CurrentPassword { get; set; }
+    public string? NewPassword { get; set; }
+    public string? NewPasswordConfirmation { get; set; }
+    public User User { get; set; } = new();
+    public IBrowserFile? ProfileImageUpload { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/DeleteRoleParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/DeleteRoleParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class DeleteRoleParameters
+{
+    public Guid RoleId { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/DeleteUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/DeleteUserParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class DeleteUserParameters
+{
+    public Guid UserId { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/ExternalLoginParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/ExternalLoginParameters.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Identity;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class ExternalLoginParameters
+{
+    public string? ProviderDisplayName { get; set; }
+    public ExternalLoginInfo? ExternalLoginInfo { get; set; }
+    public string? ReturnUrl { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/ForgotPasswordParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/ForgotPasswordParameters.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class ForgotPasswordParameters
+{
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/GetCurrentUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/GetCurrentUserParameters.cs
@@ -1,0 +1,5 @@
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class GetCurrentUserParameters
+{
+}

--- a/ZauberCMS.Core/Membership/Parameters/GetRoleParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/GetRoleParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class GetRoleParameters
+{
+    public Guid? Id { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+}

--- a/ZauberCMS.Core/Membership/Parameters/GetUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/GetUserParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class GetUserParameters
+{
+    public bool Cached { get; set; }
+    public Guid Id { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/LoginUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/LoginUserParameters.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class LoginUserParameters
+{
+    [Required]
+    [EmailAddress]
+    [Display(Name = "Email")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    [Display(Name = "Password")]
+    public string Password { get; set; } = string.Empty;
+
+    [Display(Name = "Remember me?")]
+    public bool RememberMe { get; set; }
+
+    public string? ReturnUrl { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/QueryRolesParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/QueryRolesParameters.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class QueryRolesParameters
+{
+    public List<string> Roles { get; set; } = [];
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public GetRolesOrderBy OrderBy { get; set; } = GetRolesOrderBy.DateUpdatedDescending;
+    public Expression<Func<Role, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Role>>? Query { get; set; }
+}
+
+public enum GetRolesOrderBy
+{
+    DateUpdated,
+    DateUpdatedDescending,
+    DateCreated,
+    DateCreatedDescending,
+    Name
+}

--- a/ZauberCMS.Core/Membership/Parameters/QueryUsersParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/QueryUsersParameters.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class QueryUsersParameters
+{
+    public bool Cached { get; set; }
+    public List<string> Roles { get; set; } = [];
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public string? SearchTerm { get; set; }
+    public GetUsersOrderBy OrderBy { get; set; } = GetUsersOrderBy.DateUpdatedDescending;
+    public Expression<Func<User, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<User>>? Query { get; set; }
+}
+
+public enum GetUsersOrderBy
+{
+    DateUpdated,
+    DateUpdatedDescending,
+    DateCreated,
+    DateCreatedDescending
+}

--- a/ZauberCMS.Core/Membership/Parameters/RegisterUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/RegisterUserParameters.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class RegisterUserParameters
+{
+    [Required]
+    [StringLength(150)]
+    [Display(Name = "Username")]
+    public string Username { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    [Display(Name = "Email")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 8)]
+    [DataType(DataType.Password)]
+    [Display(Name = "Password")]
+    public string Password { get; set; } = string.Empty;
+
+    [Display(Name = "Remember me?")]
+    public bool RememberMe { get; set; }
+
+    public string? ReturnUrl { get; set; }
+
+    public bool AutoLogin { get; set; } = true;
+}

--- a/ZauberCMS.Core/Membership/Parameters/ResetPasswordParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/ResetPasswordParameters.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using ZauberCMS.Core.Membership.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class ResetPasswordParameters
+{
+    [Required]
+    [EmailAddress]
+    public string? Email { get; set; }
+
+    [Required]
+    [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 8)]
+    [DataType(DataType.Password)]
+    public string? Password { get; set; }
+
+    [DataType(DataType.Password)]
+    [Display(Name = "Confirm password")]
+    [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+    public string? ConfirmPassword { get; set; }
+
+    [Required]
+    public string? Code { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/SaveRoleParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/SaveRoleParameters.cs
@@ -1,0 +1,9 @@
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class SaveRoleParameters
+{
+    public Role? Role { get; set; }
+}

--- a/ZauberCMS.Core/Membership/Parameters/SaveUserParameters.cs
+++ b/ZauberCMS.Core/Membership/Parameters/SaveUserParameters.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using ZauberCMS.Core.Membership.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Membership.Parameters;
+
+public class SaveUserParameters
+{
+    public User? User { get; set; }
+    public string? Password { get; set; }
+    public List<string>? Roles { get; set; }
+}

--- a/ZauberCMS.Core/Seo/Interfaces/ISeoService.cs
+++ b/ZauberCMS.Core/Seo/Interfaces/ISeoService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Seo.Models;
+using ZauberCMS.Core.Seo.Parameters;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Seo.Interfaces;
+
+public interface ISeoService
+{
+    Task<HandlerResult<SeoRedirect>> SaveRedirectAsync(SaveRedirectParameters parameters, CancellationToken cancellationToken = default);
+    Task<List<SeoRedirect>> QueryRedirectsAsync(QueryRedirectsParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<SeoRedirect?>> DeleteRedirectAsync(DeleteRedirectParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Seo/Parameters/DeleteRedirectParameters.cs
+++ b/ZauberCMS.Core/Seo/Parameters/DeleteRedirectParameters.cs
@@ -1,0 +1,10 @@
+using System;
+using ZauberCMS.Core.Seo.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Seo.Parameters;
+
+public class DeleteRedirectParameters
+{
+    public Guid? Id { get; set; }
+}

--- a/ZauberCMS.Core/Seo/Parameters/QueryRedirectsParameters.cs
+++ b/ZauberCMS.Core/Seo/Parameters/QueryRedirectsParameters.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ZauberCMS.Core.Seo.Models;
+
+namespace ZauberCMS.Core.Seo.Parameters;
+
+public class QueryRedirectsParameters
+{
+    public bool Cached { get; set; } = true;
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public int Amount { get; set; } = 5000;
+    public GetSeoRedirectOrderBy OrderBy { get; set; } = GetSeoRedirectOrderBy.DateUpdatedDescending;
+    public Func<IQueryable<SeoRedirect>>? Query { get; set; }
+}
+
+public enum GetSeoRedirectOrderBy
+{
+    DateCreated,
+    DateCreatedDescending,
+    DateUpdated,
+    DateUpdatedDescending,
+    FromUrl
+}

--- a/ZauberCMS.Core/Seo/Parameters/SaveRedirectParameters.cs
+++ b/ZauberCMS.Core/Seo/Parameters/SaveRedirectParameters.cs
@@ -1,0 +1,9 @@
+using ZauberCMS.Core.Seo.Models;
+using ZauberCMS.Core.Shared.Models;
+
+namespace ZauberCMS.Core.Seo.Parameters;
+
+public class SaveRedirectParameters
+{
+    public SeoRedirect? Redirect { get; set; }
+}

--- a/ZauberCMS.Core/Tags/Interfaces/ITagService.cs
+++ b/ZauberCMS.Core/Tags/Interfaces/ITagService.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+using ZauberCMS.Core.Tags.Parameters;
+
+namespace ZauberCMS.Core.Tags.Interfaces;
+
+public interface ITagService
+{
+    Task<HandlerResult<Tag>> SaveTagAsync(SaveTagParameters parameters, CancellationToken cancellationToken = default);
+    Task<PaginatedList<Tag>> QueryTagAsync(QueryTagParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<Tag?>> DeleteTagAsync(DeleteTagParameters parameters, CancellationToken cancellationToken = default);
+
+    Task<HandlerResult<TagItem>> SaveTagItemAsync(SaveTagItemParameters parameters, CancellationToken cancellationToken = default);
+    Task<HandlerResult<TagItem?>> DeleteTagItemAsync(DeleteTagItemParameters parameters, CancellationToken cancellationToken = default);
+}

--- a/ZauberCMS.Core/Tags/Parameters/DeleteTagItemParameters.cs
+++ b/ZauberCMS.Core/Tags/Parameters/DeleteTagItemParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+
+namespace ZauberCMS.Core.Tags.Parameters;
+
+public class DeleteTagItemParameters
+{
+    public Guid? TagId { get; set; }
+    public Guid? ItemId { get; set; }
+}

--- a/ZauberCMS.Core/Tags/Parameters/DeleteTagParameters.cs
+++ b/ZauberCMS.Core/Tags/Parameters/DeleteTagParameters.cs
@@ -1,0 +1,11 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+
+namespace ZauberCMS.Core.Tags.Parameters;
+
+public class DeleteTagParameters
+{
+    public Guid? Id { get; set; }
+    public string? TagName { get; set; }
+}

--- a/ZauberCMS.Core/Tags/Parameters/QueryTagParameters.cs
+++ b/ZauberCMS.Core/Tags/Parameters/QueryTagParameters.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+
+namespace ZauberCMS.Core.Tags.Parameters;
+
+public class QueryTagParameters
+{
+    public bool Cached { get; set; }
+    public bool AsNoTracking { get; set; } = true;
+    public List<Guid> Ids { get; set; } = [];
+    public List<string> TagNames { get; set; } = [];
+    public List<string> TagSlugs { get; set; } = [];
+    public List<Guid> ItemIds { get; set; } = [];
+    public int PageIndex { get; set; } = 1;
+    public int AmountPerPage { get; set; } = 10;
+    public GetTagOrderBy OrderBy { get; set; } = GetTagOrderBy.TagName;
+    public Expression<Func<Tag, bool>>? WhereClause { get; set; }
+    public Func<IQueryable<Tag>>? Query { get; set; }
+}
+
+public enum GetTagOrderBy
+{
+    DateCreated,
+    DateCreatedDescending,
+    TagName,
+    TagNameDescending,
+    SortOrder
+}

--- a/ZauberCMS.Core/Tags/Parameters/SaveTagItemParameters.cs
+++ b/ZauberCMS.Core/Tags/Parameters/SaveTagItemParameters.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+
+namespace ZauberCMS.Core.Tags.Parameters;
+
+public class SaveTagItemParameters
+{
+    public List<Guid> TagIds { get; set; } = [];
+    public Guid ItemId { get; set; }
+}

--- a/ZauberCMS.Core/Tags/Parameters/SaveTagParameters.cs
+++ b/ZauberCMS.Core/Tags/Parameters/SaveTagParameters.cs
@@ -1,0 +1,12 @@
+using System;
+using ZauberCMS.Core.Shared.Models;
+using ZauberCMS.Core.Tags.Models;
+
+namespace ZauberCMS.Core.Tags.Parameters;
+
+public class SaveTagParameters
+{
+    public Guid? Id { get; set; }
+    public string? TagName { get; set; }
+    public int SortOrder { get; set; }
+}


### PR DESCRIPTION
Begins MediatR replacement by introducing new service interfaces, parameter classes, and `ContentService` implementation.

This PR completes Phase 1 (service interfaces) and Phase 2 (parameter classes) for all core domains (Audit, Content, Data, Email, Language, Media, Membership, SEO, Tags). It also initiates Phase 3 by implementing the `ContentService`, porting logic from existing MediatR handlers and ensuring no new mediator dependencies are introduced.

---
<a href="https://cursor.com/background-agent?bcId=bc-d17698f5-0b12-459a-97a6-fbb621a19a50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d17698f5-0b12-459a-97a6-fbb621a19a50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

