### PR TITLE
feat: Allow programmatic configuration of ZauberCMS settings

### DIFF
--- a/ZauberCMS.Core/Content/Mapping/ContentVersionDbMapping.cs
+++ b/ZauberCMS.Core/Content/Mapping/ContentVersionDbMapping.cs
@@ -46,17 +46,5 @@ public class ContentVersionDbMapping : IEntityTypeConfiguration<ContentVersion>
             .WithMany()
             .HasForeignKey(d => d.ParentVersionId)
             .OnDelete(DeleteBehavior.NoAction);
-
-        // Ensure only one current published version per content
-        builder.HasIndex(x => x.ContentId)
-            .HasFilter("[IsCurrentPublished] = 1")
-            .HasDatabaseName("IX_ContentVersion_UniqueCurrentPublished")
-            .IsUnique();
-
-        // Ensure only one latest draft per content
-        builder.HasIndex(x => x.ContentId)
-            .HasFilter("[IsLatestDraft] = 1")
-            .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft")
-            .IsUnique();
     }
 }

--- a/ZauberCMS.Core/Data/Migrations/PostgreSql/20250924143438_Initial.Designer.cs
+++ b/ZauberCMS.Core/Data/Migrations/PostgreSql/20250924143438_Initial.Designer.cs
@@ -366,7 +366,7 @@ namespace ZauberCMS.Core.Data.Migrations.PostgreSql
                     b.HasIndex("ContentId")
                         .IsUnique()
                         .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft")
-                        .HasFilter("[IsLatestDraft] = 1");
+                        .HasFilter("\"IsLatestDraft\" = true");
 
                     b.HasIndex("CreatedById");
 

--- a/ZauberCMS.Core/Data/Migrations/PostgreSql/20250924143438_Initial.cs
+++ b/ZauberCMS.Core/Data/Migrations/PostgreSql/20250924143438_Initial.cs
@@ -741,7 +741,7 @@ namespace ZauberCMS.Core.Data.Migrations.PostgreSql
                 table: "ZauberContentVersions",
                 column: "ContentId",
                 unique: true,
-                filter: "[IsLatestDraft] = 1");
+                filter: "\"IsLatestDraft\" = true");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ZauberContentVersions_CreatedById",

--- a/ZauberCMS.Core/Data/Migrations/PostgreSql/PostgreSqlZauberDbContextModelSnapshot.cs
+++ b/ZauberCMS.Core/Data/Migrations/PostgreSql/PostgreSqlZauberDbContextModelSnapshot.cs
@@ -363,7 +363,7 @@ namespace ZauberCMS.Core.Data.Migrations.PostgreSql
                     b.HasIndex("ContentId")
                         .IsUnique()
                         .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft")
-                        .HasFilter("[IsLatestDraft] = 1");
+                        .HasFilter("\"IsLatestDraft\" = true");
 
                     b.HasIndex("CreatedById");
 

--- a/ZauberCMS.Core/Data/PostgreSqlZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/PostgreSqlZauberDbContext.cs
@@ -1,20 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
 
 public class PostgreSqlZauberDbContext(
     DbContextOptions<PostgreSqlZauberDbContext> options,
-    IConfiguration configuration)
-    : ZauberDbContextBase(options, configuration), IZauberDbContext
+    IOptions<ZauberSettings> settings)
+    : ZauberDbContextBase(options), IZauberDbContext
 {
-    private readonly IConfiguration _configuration = configuration;
-
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        var section = _configuration.GetSection("Zauber");
-        var connectionString = section.GetValue<string>("ConnectionString");
+        var connectionString = settings.Value.ConnectionString;
         options.UseNpgsql(connectionString, builder =>
         {
             builder.MigrationsHistoryTable(tableName: "ZauberMigrations");

--- a/ZauberCMS.Core/Data/PostgreSqlZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/PostgreSqlZauberDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Content.Models;
 using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
@@ -23,5 +24,18 @@ public class PostgreSqlZauberDbContext(
 #endif
         options
             .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Ensure only one current published version per content
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("\"IsCurrentPublished\" = true")
+            .HasDatabaseName("IX_ContentVersion_UniqueCurrentPublished").IsUnique();
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("\"IsLatestDraft\" = true")
+            .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft").IsUnique();
     }
 }

--- a/ZauberCMS.Core/Data/SqliteZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/SqliteZauberDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Content.Models;
 using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
@@ -24,5 +25,18 @@ public class SqliteZauberDbContext(
         options
             .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
 
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Ensure only one current published version per content
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("\"IsCurrentPublished\" = 1")
+            .HasDatabaseName("IX_ContentVersion_UniqueCurrentPublished").IsUnique();
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("\"IsLatestDraft\" = 1")
+            .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft").IsUnique();
     }
 }

--- a/ZauberCMS.Core/Data/SqliteZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/SqliteZauberDbContext.cs
@@ -1,20 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
 
 public class SqliteZauberDbContext(
     DbContextOptions<SqliteZauberDbContext> options, 
-    IConfiguration configuration) 
-    : ZauberDbContextBase(options, configuration), IZauberDbContext
+    IOptions<ZauberSettings> settings) 
+    : ZauberDbContextBase(options), IZauberDbContext
 {
-    private readonly IConfiguration _configuration = configuration;
-
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        var section = _configuration.GetSection("Zauber");
-        var connectionString = section.GetValue<string>("ConnectionString");
+        var connectionString = settings.Value.ConnectionString;
         options.UseSqlite(connectionString, builder =>
         {
             builder.MigrationsHistoryTable(tableName: "ZauberMigrations");

--- a/ZauberCMS.Core/Data/ZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/ZauberDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Content.Models;
 using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
@@ -23,5 +24,18 @@ public class ZauberDbContext(
 #endif
         options
             .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Ensure only one current published version per content
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("[IsCurrentPublished] = 1")
+            .HasDatabaseName("IX_ContentVersion_UniqueCurrentPublished").IsUnique();
+        modelBuilder.Entity<ContentVersion>().HasIndex(x => x.ContentId)
+            .HasFilter("[IsLatestDraft] = 1")
+            .HasDatabaseName("IX_ContentVersion_UniqueLatestDraft").IsUnique();
     }
 }

--- a/ZauberCMS.Core/Data/ZauberDbContext.cs
+++ b/ZauberCMS.Core/Data/ZauberDbContext.cs
@@ -1,18 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data;
 
-public class ZauberDbContext(DbContextOptions<ZauberDbContext> options, IConfiguration configuration)
-    : ZauberDbContextBase(options, configuration), IZauberDbContext
+public class ZauberDbContext(
+    DbContextOptions<ZauberDbContext> options,
+    IOptions<ZauberSettings> settings)
+    : ZauberDbContextBase(options), IZauberDbContext
 {
-    private readonly IConfiguration _configuration = configuration;
-
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        var section = _configuration.GetSection("Zauber");
-        var connectionString = section.GetValue<string>("ConnectionString");
+        var connectionString = settings.Value.ConnectionString;
         options.UseSqlServer(connectionString, builder =>
         {
             builder.MigrationsHistoryTable(tableName: "ZauberMigrations");

--- a/ZauberCMS.Core/Data/ZauberDbContextBase.cs
+++ b/ZauberCMS.Core/Data/ZauberDbContextBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using ZauberCMS.Core.Content.Models;
@@ -12,12 +11,9 @@ using ZauberCMS.Core.Tags.Models;
 
 namespace ZauberCMS.Core.Data
 {
-    public abstract class ZauberDbContextBase(DbContextOptions options, IConfiguration configuration)
+    public abstract class ZauberDbContextBase(DbContextOptions options)
         : IdentityDbContext<User, Role, Guid, UserClaim, UserRole, UserLogin, RoleClaim, UserToken>(options)
     {
-        // ReSharper disable once UnusedMember.Local
-        private readonly IConfiguration _configuration = configuration;
-        
         // All DbSets
         public DbSet<ContentType> ContentTypes => Set<ContentType>();
         public DbSet<Content.Models.Content> Contents => Set<Content.Models.Content>();

--- a/ZauberCMS.Core/Data/ZauberDesignTimeDbContextFactory.cs
+++ b/ZauberCMS.Core/Data/ZauberDesignTimeDbContextFactory.cs
@@ -1,66 +1,61 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using ZauberCMS.Core.Settings;
 
 namespace ZauberCMS.Core.Data
 {
     public class ZauberDesignTimeDbContextFactory : IDesignTimeDbContextFactory<ZauberDbContext>
     {
+        private readonly IOptions<ZauberSettings> _zauberSettings;
+
+        public ZauberDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
+        {
+            _zauberSettings = zauberSettings;
+        }
+        
         public ZauberDbContext CreateDbContext(string[] args)
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../ZauberCMS"))
-                .AddJsonFile("appSettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appSettings.{environment}.json", optional: true)
-                .Build();
-
-            var connectionString = configuration.GetSection("Zauber").GetValue<string>("ConnectionString");
-
             var optionsBuilder = new DbContextOptionsBuilder<ZauberDbContext>();
-            optionsBuilder.UseSqlServer(connectionString, builder => builder.MigrationsHistoryTable(tableName: "ZauberMigrations"));
+            optionsBuilder.UseSqlServer(_zauberSettings.Value.ConnectionString, builder => builder.MigrationsHistoryTable(tableName: "ZauberMigrations"));
 
-            return new ZauberDbContext(optionsBuilder.Options, configuration);
+            return new ZauberDbContext(optionsBuilder.Options, _zauberSettings);
         }
     }
-
+    
     public class ZauberSqliteDesignTimeDbContextFactory : IDesignTimeDbContextFactory<SqliteZauberDbContext>
     {
+        private readonly IOptions<ZauberSettings> _zauberSettings;
+
+        public ZauberSqliteDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
+        {
+            _zauberSettings = zauberSettings;
+        }
+
         public SqliteZauberDbContext CreateDbContext(string[] args)
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../ZauberCMS"))
-                .AddJsonFile("appSettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appSettings.{environment}.json", optional: true)
-                .Build();
-
-            var connectionString = configuration.GetSection("Zauber").GetValue<string>("ConnectionString");
-
             var optionsBuilder = new DbContextOptionsBuilder<SqliteZauberDbContext>();
-            optionsBuilder.UseSqlite(connectionString);
+            optionsBuilder.UseSqlite(_zauberSettings.Value.ConnectionString);
 
-            return new SqliteZauberDbContext(optionsBuilder.Options, configuration);
+            return new SqliteZauberDbContext(optionsBuilder.Options, _zauberSettings);
         }
     }
 
     public class ZauberPostgreSqlDesignTimeDbContextFactory : IDesignTimeDbContextFactory<PostgreSqlZauberDbContext>
     {
+        private readonly IOptions<ZauberSettings> _zauberSettings;
+
+        public ZauberPostgreSqlDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
+        {
+            _zauberSettings = zauberSettings;
+        }
+
         public PostgreSqlZauberDbContext CreateDbContext(string[] args)
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../ZauberCMS"))
-                .AddJsonFile("appSettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appSettings.{environment}.json", optional: true)
-                .Build();
-
-            var connectionString = configuration.GetSection("Zauber").GetValue<string>("ConnectionString");
-
             var optionsBuilder = new DbContextOptionsBuilder<PostgreSqlZauberDbContext>();
-            optionsBuilder.UseNpgsql(connectionString, builder => builder.MigrationsHistoryTable(tableName: "ZauberMigrations"));
+            optionsBuilder.UseNpgsql(_zauberSettings.Value.ConnectionString, builder => builder.MigrationsHistoryTable(tableName: "ZauberMigrations"));
 
-            return new PostgreSqlZauberDbContext(optionsBuilder.Options, configuration);
+            return new PostgreSqlZauberDbContext(optionsBuilder.Options, _zauberSettings);
         }
     }
 }

--- a/ZauberCMS.Core/Data/ZauberDesignTimeDbContextFactory.cs
+++ b/ZauberCMS.Core/Data/ZauberDesignTimeDbContextFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using ZauberCMS.Core.Settings;
 
@@ -8,6 +9,12 @@ namespace ZauberCMS.Core.Data
     public class ZauberDesignTimeDbContextFactory : IDesignTimeDbContextFactory<ZauberDbContext>
     {
         private readonly IOptions<ZauberSettings> _zauberSettings;
+
+        public ZauberDesignTimeDbContextFactory()
+            : this(new DesignTimeZauberSettingsOptions())
+        {
+
+        }
 
         public ZauberDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
         {
@@ -27,6 +34,12 @@ namespace ZauberCMS.Core.Data
     {
         private readonly IOptions<ZauberSettings> _zauberSettings;
 
+        public ZauberSqliteDesignTimeDbContextFactory()
+            : this(new DesignTimeZauberSettingsOptions())
+        {
+
+        }
+
         public ZauberSqliteDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
         {
             _zauberSettings = zauberSettings;
@@ -45,6 +58,12 @@ namespace ZauberCMS.Core.Data
     {
         private readonly IOptions<ZauberSettings> _zauberSettings;
 
+        public ZauberPostgreSqlDesignTimeDbContextFactory() 
+            : this(new DesignTimeZauberSettingsOptions())
+        {
+            
+        }
+        
         public ZauberPostgreSqlDesignTimeDbContextFactory(IOptions<ZauberSettings> zauberSettings)
         {
             _zauberSettings = zauberSettings;
@@ -56,6 +75,26 @@ namespace ZauberCMS.Core.Data
             optionsBuilder.UseNpgsql(_zauberSettings.Value.ConnectionString, builder => builder.MigrationsHistoryTable(tableName: "ZauberMigrations"));
 
             return new PostgreSqlZauberDbContext(optionsBuilder.Options, _zauberSettings);
+        }
+    }
+    
+    internal class DesignTimeZauberSettingsOptions: IOptions<ZauberSettings>
+    {
+        public  ZauberSettings Value { get; }
+        internal DesignTimeZauberSettingsOptions()
+        {
+            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../ZauberCMS"))
+                .AddJsonFile("appSettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appSettings.{environment}.json", optional: true)
+                .Build();
+
+            var settings = new ZauberSettings();
+
+            configuration.GetSection("Zauber").Bind(settings);
+            
+            Value = settings;
         }
     }
 }

--- a/ZauberCMS.Core/ZauberSetup.cs
+++ b/ZauberCMS.Core/ZauberSetup.cs
@@ -57,7 +57,13 @@ namespace ZauberCMS.Core;
 
 public static class ZauberSetup
 {
+    // Keeping this method to be compile time compatible with the previous version, if that isn't needed this can be removed and the configureSettings can be defaulted to null
     public static void AddZauberCms(this WebApplicationBuilder builder, params Assembly[] additionalAssemblies)
+    {
+        AddZauberCms(builder, null, additionalAssemblies);
+    }
+
+    public static void AddZauberCms(this WebApplicationBuilder builder, Action<ZauberSettings>? configureSettings, params Assembly[] additionalAssemblies)
     {
         builder.Host.UseSerilog((context, configuration) =>
             configuration.ReadFrom.Configuration(context.Configuration));
@@ -69,6 +75,14 @@ public static class ZauberSetup
         var zauberSettings = new ZauberSettings();
         builder.Configuration.GetSection(Constants.SettingsConfigName).Bind(zauberSettings);
         builder.Services.Configure<ZauberSettings>(builder.Configuration.GetSection(Constants.SettingsConfigName));
+
+        if (configureSettings is not null)
+        {
+            // Apply any additional configuration from the user
+            configureSettings.Invoke(zauberSettings);
+            // Apply any additional configuration from the user to the options system as well, so it's available in IOptions<ZauberSettings>
+            builder.Services.Configure(configureSettings);
+        }
 
         // Configure ImageResize with settings from ZauberSettings
         builder.Services.AddImageResize(o =>

--- a/ZauberCMS.Web/Program.cs
+++ b/ZauberCMS.Web/Program.cs
@@ -3,11 +3,7 @@ using ZauberCMS.Core;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddZauberCms(settings =>
-{
-    settings.DatabaseProvider = "postgresql";
-    settings.ConnectionString = "Host=localhost;Port=51020;Username=postgres;Password=dCW7{-YUH9u8_8uv~W{M}x;Database=cms";
-});
+builder.AddZauberCms();
 
 var app = builder.Build();
 

--- a/ZauberCMS.Web/Program.cs
+++ b/ZauberCMS.Web/Program.cs
@@ -3,7 +3,11 @@ using ZauberCMS.Core;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddZauberCms();
+builder.AddZauberCms(settings =>
+{
+    settings.DatabaseProvider = "postgresql";
+    settings.ConnectionString = "Host=localhost;Port=51020;Username=postgres;Password=dCW7{-YUH9u8_8uv~W{M}x;Database=cms";
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
Refactor DbContexts and design-time factories to consume settings via `IOptions` instead of directly from `IConfiguration`. This enables the `AddZauberCms` setup method to accept a configuration action, providing a code-first approach for defining critical settings such as the database connection.

And fixed Postgres Migration issue for the filter for IsLatestDraft using brackets instead of quotes for escaping